### PR TITLE
ElysiumRemastered.c5m bugfixes

### DIFF
--- a/ElysiumRemastered.c5m
+++ b/ElysiumRemastered.c5m
@@ -9082,7 +9082,7 @@ newritual "Design Skull Tattoo"
 copyritual "Design Skull Tattoo"
 cost 2 0 
 level 3
-descr "The Wotan designs a Skull Tattoo that grants painted barbarians flesh almost impervious to physical damage. Only clubs and hammers that crush the bones of Amazons will cause severe wounds."
+descr "The Wotan designs a Skull Tattoo that grants painted barbarians flesh almost impervious to physical damage. Only clubs and hammers that crush the bones of barbarians will cause severe wounds."
 
 newritual "Design Tattoo of Rebirth"
 copyritual "Design Hydra Tattoo"


### PR DESCRIPTION
Hi, I've been collecting some bugs and odd stuff for some time so here they are.

Baron:
Fay Knight and Fay Warrior are moved to the front rank

Necromancer:
Re-added Scout as a merc recruitment offer

Demonologist:
Demons can no longer learn Soul Contract. Description re-added. 
"Bind Demon Lord" ritual can now be learned without Greater Demonic Tutelage

Bakemono:
Vanilla "Summon King" ritual removed

Barbarian:
Tattoo rituals' descriptions added 

Burgmeister:
Horticulturists can now be recruited with a Steel Chancellor present on a map (typo fix)

Illusionist:
Gilded Cavalrymen can now be properly recruited (typo fix). 
Gilded Captain rec offer chance: 2% -> 15%

Other:
All assassination attacks are now armor negating (changes made to: Red Toad Headhunter, Anguifer, Vespertine Agent, Hobmark Murderer)